### PR TITLE
Added shell32 lib to link against

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -18,6 +18,7 @@ fn main() {
     if cfg!(target_os = "windows") {
         println!("cargo:rustc-link-lib=dylib=gdi32");
         println!("cargo:rustc-link-lib=dylib=user32");
+        println!("cargo:rustc-link-lib=dylib=shell32");
     }
     if cfg!(target_os = "linux") {
         println!("cargo:rustc-link-search=/usr/local/lib");


### PR DESCRIPTION
Unresolved external linker errors were occurring because shell32 was removed from the standard library. There for explicit linking is required. More info here: https://github.com/rust-lang/rust/issues/56839