### PR TITLE
Remove link args from raylib when building with cargo-web

### DIFF
--- a/raylib/Web.toml
+++ b/raylib/Web.toml
@@ -15,8 +15,3 @@ default-target = "wasm32-unknown-emscripten"
 # Asserts the minimum required version of `cargo-web` necessary
 # to compile this crate; supported since 0.6.0.
 minimum-version = "0.6.0"
-
-[target.emscripten]
-# This will enable Emscripten's SDL2 port. Consult Emscripten's documentation
-# for more details.
-link-args = ["-s", "USE_GLFW=3", "-s", "ASSERTIONS=1", "-s",  "ASYNCIFY=1", "--profiling"]


### PR DESCRIPTION
The `link-args` of `samples/Web.toml` are enough, since the ones added from `raylib/Web.toml` are duplicated and unnecessary. Since link args are only used for the final output and all link args from every Web.toml of every crate are used, we don't need this duplicity.

Also, by not forcing any link args on raylib, we can let users specify the flags they need. For instance, with `fastcomp-latest` the `ASYNCIFY` option is not supported anymore:

`= note: shared:ERROR: ASYNCIFY has been removed from fastcomp. There is a new implementation which can be used in the upstream wasm backend.`