### PR TITLE
Fixed Texture2D.height() calls

### DIFF
--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -679,7 +679,7 @@ impl Texture2D {
     }
 
     pub fn height(&self) -> i32 {
-        self.0.width
+        self.0.height
     }
 
     pub fn mipmaps(&self) -> i32 {


### PR DESCRIPTION
`Texture2D.height()` return the width strangely but `Texture2D.height` is unaffected.