### PR TITLE
Produce color from hex RGB strings

### DIFF
--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -40,6 +40,29 @@ impl From<(u8, u8, u8, u8)> for Color {
     }
 }
 
+impl From<&str> for Color {
+    /// Get color from HEX RGB string
+    /// # Arguments
+    /// * `color_hex_str` - A string slice, 6 characters long
+    /// # Example
+    /// ```
+    /// let color = Color::from("FAFB09");
+    /// ```
+    fn from(color_hex_str: &str) -> Color {
+        let color = i32::from_str_radix(color_hex_str, 16).unwrap();
+        let b = color % 0x100;
+        let g = (color - b) / 0x100 % 0x100;
+        let r = (color - g) / 0x10000;
+
+        Color {
+            r: r as u8,
+            g: g as u8,
+            b: b as  u8,
+            a: 255
+        }
+    }
+}
+
 impl Color {
     pub const LIGHTGRAY: Color = Color {
         r: 200,
@@ -232,4 +255,13 @@ impl Color {
     pub fn fade(&self, alpha: f32) -> Color {
         unsafe { ffi::Fade(self.into(), alpha).into() }
     }
+}
+
+#[test]
+fn test_color_macro () {
+    let color_white = Color::from("FFFFFF");
+    let color_black = Color::from("000000");
+
+    assert_eq!(color_black, Color::BLACK);
+    assert_eq!(color_white, Color::WHITE);
 }


### PR DESCRIPTION
Implemented `From<&str>` for colors.

Once const functions are stable in Rust, this could be turned into a compile-time macro, so one can initialize constant values in their color schemes in a sound and pleasant manner.