### PR TITLE
Fix to normalized() for Vector3

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -421,8 +421,8 @@ impl Vector3 {
 
         Vector3 {
             x: self.x * ilength,
-            y: self.x * ilength,
-            z: self.x * ilength,
+            y: self.y * ilength,
+            z: self.z * ilength,
         }
     }
 


### PR DESCRIPTION
The current implementation returns a "normalized" vector as the vector where each component is the x component divided by the length of the vector.