### PR TITLE
remove check for bones and poses in load_model_from_mesh

### DIFF
--- a/raylib-test/src/models.rs
+++ b/raylib-test/src/models.rs
@@ -23,4 +23,22 @@ mod model_test {
         let _ = ModelAnimation::load_model_animations("resources/guy/guyanim.iqm")
             .expect("could not load model animations");
     }
+
+    ray_test!(test_model_from_generated_mesh);
+    fn test_model_from_generated_mesh(thread: &RaylibThread){
+        let mut handle = TEST_HANDLE.write().unwrap();
+        let rl = handle.as_mut().unwrap();
+
+        let mesh = Mesh::gen_mesh_cube(&thread, 1.0, 1.0, 1.0);
+        let model = rl.load_model_from_mesh(&thread, &mesh).unwrap();
+
+        let zero = Vector3::zero();
+
+        let camera = Camera3D::perspective(zero, zero, zero, 10.0);
+
+        let mut d = rl.begin_drawing(&thread);
+        let mut world = d.begin_mode_3D(&camera);
+
+        world.draw_model(&model, zero, 1.0, Color::RED);
+    }
 }

--- a/raylib/src/core/models.rs
+++ b/raylib/src/core/models.rs
@@ -47,7 +47,7 @@ impl RaylibHandle {
     pub fn load_model_from_mesh(&mut self, _: &RaylibThread, mesh: &Mesh) -> Result<Model, String> {
         let m = unsafe { ffi::LoadModelFromMesh(mesh.0) };
 
-        if m.meshes.is_null() || m.materials.is_null() || m.bones.is_null() || m.bindPose.is_null()
+        if m.meshes.is_null() || m.materials.is_null()
         {
             return Err("Could not load model from mesh".to_owned());
         }


### PR DESCRIPTION
This check doesn't allow for meshes generated using the gen_mesh methods like gen_mesh_cube.
It should fix issue #57 
let me know if I should do something else with this... I'd be happy to improve the PR in any way necessary