### PR TITLE
Use proper pointer types for architecture (Fixes #10)

### DIFF
--- a/raylib/src/core/shaders.rs
+++ b/raylib/src/core/shaders.rs
@@ -5,7 +5,7 @@ use crate::core::math::{Vector2, Vector3, Vector4};
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::CString;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 
 fn no_drop<T>(_thing: T) {}
 make_thin_wrapper!(Shader, ffi::Shader, ffi::UnloadShader);
@@ -51,19 +51,19 @@ impl RaylibHandle {
         return match (c_vs_code, c_fs_code) {
             (Some(vs), Some(fs)) => unsafe {
                 Shader(ffi::LoadShaderCode(
-                    vs.as_ptr() as *mut i8,
-                    fs.as_ptr() as *mut i8,
+                    vs.as_ptr() as *mut c_char,
+                    fs.as_ptr() as *mut c_char,
                 ))
             },
             (None, Some(fs)) => unsafe {
                 Shader(ffi::LoadShaderCode(
                     std::ptr::null_mut(),
-                    fs.as_ptr() as *mut i8,
+                    fs.as_ptr() as *mut c_char,
                 ))
             },
             (Some(vs), None) => unsafe {
                 Shader(ffi::LoadShaderCode(
-                    vs.as_ptr() as *mut i8,
+                    vs.as_ptr() as *mut c_char,
                     std::ptr::null_mut(),
                 ))
             },

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -3,6 +3,7 @@ use crate::core::math::{Matrix, Ray, Vector2};
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::{CStr, CString, IntoStringError, NulError};
+use std::os::raw::c_char;
 
 // MonitorInfo grabs the sizes (virtual and physical) of your monitor
 #[derive(Clone, Debug)]
@@ -68,7 +69,7 @@ pub fn get_monitor_name(monitor: i32) -> Result<String, IntoStringError> {
     debug_assert!(monitor < len && monitor >= 0, "monitor index out of range");
 
     Ok(unsafe {
-        let c = CString::from_raw(ffi::GetMonitorName(monitor) as *mut i8);
+        let c = CString::from_raw(ffi::GetMonitorName(monitor) as *mut c_char);
         c.into_string()?
     })
 }
@@ -138,7 +139,7 @@ impl RaylibHandle {
     pub fn get_clipboard_text(&self) -> Result<String, std::str::Utf8Error> {
         unsafe {
             let c = ffi::GetClipboardText();
-            let c = CStr::from_ptr(c as *mut i8);
+            let c = CStr::from_ptr(c as *mut c_char);
             c.to_str().map(|s| s.to_owned())
         }
     }


### PR DESCRIPTION
I'm working with this library, trying to get it running on the Pi. On ARM systems, Rust uses`u8` for `char *` rather than `i8`. The most portable thing to do here would be to cast as `std::os::raw::c_char` instead of `i8` (Fixes #10).