### PR TITLE
Fix Windows cross-compile issues from Linux

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -251,7 +251,8 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
         // Determine PLATFORM_OS in case PLATFORM_DESKTOP selected
         if env::var("OS")
             .unwrap_or("".to_owned())
-            .contains("Windows_NT")
+            .contains("Windows_NT") || env::var("TARGET").unwrap_or("".to_owned())
+            .contains("windows")
         {
             // No uname.exe on MinGW!, but OS=Windows_NT on Windows!
             // ifeq ($(UNAME),Msys) -> Windows

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -84,6 +84,8 @@ fn build_with_cmake(src_path: &str) {
                 dst_lib.join("libraylib_static.a"),
                 dst_lib.join("libraylib.a"),
             ).expect("filed to create windows library");
+        } else if Path::new(&dst_lib.join("libraylib.a")).exists() {
+            // DO NOTHING
         } else {
             panic!("filed to create windows library");
         }


### PR DESCRIPTION
This PR fixes #66, #73, and probably #75.

Since cmake will produce `libraylib.a` when cross-compiling, the `build.rs` will now handle it correctly and not fail.

I also made the "is windows" check reference the compiler triple so that the library can be cross-compiled using cargo's `--target` option no matter the host OS