### PR TITLE
Add optional interop with nalgebra

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -18,11 +18,13 @@ lazy_static = "1.2.0"
 cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
+nalgebra = { version = "0.26", optional = true }
 
 [features]
 nightly = []
 nobuild = ["raylib-sys/nobuild"]
 with_serde = ["serde", "serde_json"]
+nalgebra_interop = ["nalgebra"]
 
 [package.metadata.docs.rs]
 features = ["nobuild"]

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -49,6 +49,33 @@ optional_serde_struct! {
     }
 }
 
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::Vector2<f32>> for Vector2 {
+    fn from(v: na::Vector2<f32>) -> Vector2 {
+        Vector2 {
+            x: v.x,
+            y: v.y
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::base::coordinates::XY<f32>> for Vector2 {
+    fn from(v: na::base::coordinates::XY<f32>) -> Vector2 {
+        Vector2 {
+            x: v.x,
+            y: v.y
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl Into<na::Vector2<f32>> for Vector2 {
+    fn into(self) -> na::Vector2<f32> {
+        na::Vector2::new(self.x, self.y)
+    }
+}
+
 impl From<ffi::Vector2> for Vector2 {
     fn from(v: ffi::Vector2) -> Vector2 {
         unsafe { std::mem::transmute(v) }
@@ -315,6 +342,35 @@ optional_serde_struct! {
         pub x: f32,
         pub y: f32,
         pub z: f32,
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::Vector3<f32>> for Vector3 {
+    fn from(v: na::Vector3<f32>) -> Vector3 {
+        Vector3 {
+            x: v.x,
+            y: v.y,
+            z: v.z
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::base::coordinates::XYZ<f32>> for Vector3 {
+    fn from(v: na::base::coordinates::XYZ<f32>) -> Vector3 {
+        Vector3 {
+            x: v.x,
+            y: v.y,
+            z: v.z
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl Into<na::Vector3<f32>> for Vector3 {
+    fn into(self) -> na::Vector3<f32> {
+        na::Vector3::new(self.x, self.y, self.z)
     }
 }
 

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -21,6 +21,8 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 
 #[cfg(feature = "with_serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "nalgebra_interop")]
+use nalgebra as na;
 
 make_rslice!(RSliceVec4, Vector4, ffi::MemFree);
 

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -796,6 +796,37 @@ optional_serde_struct! {
 }
 pub type Quaternion = Vector4;
 
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::Vector4<f32>> for Vector4 {
+    fn from(v: na::Vector4<f32>) -> Vector4 {
+        Vector4 {
+            x: v.x,
+            y: v.y,
+            z: v.z,
+            w: v.w
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::base::coordinates::XYZW<f32>> for Vector4 {
+    fn from(v: na::base::coordinates::XYZW<f32>) -> Vector4 {
+        Vector4 {
+            x: v.x,
+            y: v.y,
+            z: v.z,
+            w: v.w
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl Into<na::Vector4<f32>> for Vector4 {
+    fn into(self) -> na::Vector4<f32> {
+        na::Vector4::new(self.x, self.y, self.z, self.w)
+    }
+}
+
 impl From<ffi::Vector4> for Vector4 {
     fn from(v: ffi::Vector4) -> Vector4 {
         unsafe { std::mem::transmute(v) }
@@ -1124,6 +1155,25 @@ impl Quaternion {
             z: mat.m2 * self.x + mat.m6 * self.y + mat.m10 * self.z + mat.m14 * self.w,
             w: mat.m3 * self.x + mat.m7 * self.y + mat.m11 * self.z + mat.m15 * self.w,
         }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl From<na::geometry::Quaternion<f32>> for Quaternion {
+    fn from(q: na::geometry::Quaternion<f32>) -> Quaternion {
+        Quaternion {
+            x: q.coords.x,
+            y: q.coords.y,
+            z: q.coords.z,
+            w: q.coords.w
+        }
+    }
+}
+
+#[cfg(feature = "nalgebra_interop")]
+impl Into<na::geometry::Quaternion<f32>> for Quaternion {
+    fn into(self) -> na::geometry::Quaternion<f32> {
+        na::geometry::Quaternion::new(self.x, self.y, self.z, self.w)
     }
 }
 

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -73,3 +73,9 @@ pub use crate::core::file::*;
 pub use crate::core::logging::*;
 pub use crate::core::misc::{get_random_value, open_url};
 pub use crate::core::*;
+
+// Re-exports
+#[cfg(feature = "with_serde")]
+pub use serde;
+#[cfg(feature = "nalgebra_interop")]
+pub use nalgebra as na;


### PR DESCRIPTION
I like to use the [nalgebra](https://nalgebra.org/) library for my linear algebra needs. This PR just adds an optional feature to this library (`nalgebra_interop`) that implements `Into` and `From` traits between the raylib vector types and the nalgebra ones.

