### PR TITLE
Added binding for LoadImageFromMemory

### DIFF
--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -692,6 +692,19 @@ impl Image {
         }
         Ok(Image(i))
     }
+    
+    /// Loads image from a given memory buffer as a vector of arrays
+    pub fn load_image_from_mem(filetype: &str, bytes: &Vec<u8>, size: i32) -> Result<Image, String> {
+        let c_filetype = CString::new(filetype).unwrap();
+        let c_bytes = bytes.as_ptr();
+        let i = unsafe { ffi::LoadImageFromMemory(c_filetype.as_ptr(), c_bytes, size) };
+        if i.data.is_null() {
+            return Err(format!(
+            "Image data is null. Check provided buffer data"
+            ))
+        };
+        Ok(Image(i))
+    }
 
     /// Loads image from RAW file data.
     pub fn load_image_raw(


### PR DESCRIPTION
Added a wrapper for LoadImageFromMemory. This allows "bundling" data in the binary itself via the rust include_bytes! macro.