### PR TITLE
Add initialization option for replacing the internal logger with the Rust `log` crate

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -22,6 +22,7 @@ nalgebra = { version = "0.26", optional = true }
 num-traits = "0.2.14"
 printf = "0.1.0"
 log = "0.4.14"
+num-derive = "0.3.3"
 
 [features]
 nightly = []

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -19,6 +19,9 @@ cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
+num-traits = "0.2.14"
+printf = "0.1.0"
+log = "0.4.14"
 
 [features]
 nightly = []

--- a/raylib/src/core/log_hooks.rs
+++ b/raylib/src/core/log_hooks.rs
@@ -32,15 +32,15 @@ pub unsafe extern "C" fn log_callback(
     // Handle the log level and fall back on info!
     match RaylibLogLevel::from_u32(level.try_into().unwrap()) {
         Some(level) => match level {
-            RaylibLogLevel::Trace => log::trace!("{}", formatted_message),
-            RaylibLogLevel::Debug => log::debug!("{}", formatted_message),
-            RaylibLogLevel::Warning => log::warn!("{}", formatted_message),
-            RaylibLogLevel::Error => log::error!("{}", formatted_message),
-            RaylibLogLevel::Fatal => log::error!("{}", formatted_message),
-            _ => log::info!("{}", formatted_message),
+            RaylibLogLevel::Trace => log::trace!(target:"raylib", "{}", formatted_message),
+            RaylibLogLevel::Debug => log::debug!(target:"raylib", "{}", formatted_message),
+            RaylibLogLevel::Warning => log::warn!(target:"raylib", "{}", formatted_message),
+            RaylibLogLevel::Error => log::error!(target:"raylib", "{}", formatted_message),
+            RaylibLogLevel::Fatal => log::error!(target:"raylib", "{}", formatted_message),
+            _ => log::info!(target:"raylib", "{}", formatted_message),
         },
         None => {
-            log::info!("{}", formatted_message)
+            log::info!(target:"raylib", "{}", formatted_message)
         }
     }
 }

--- a/raylib/src/core/log_hooks.rs
+++ b/raylib/src/core/log_hooks.rs
@@ -1,0 +1,46 @@
+//! Contains utilities for replacing the raylib logger with the `log` create.
+
+use std::{convert::TryInto, ffi::c_void};
+
+use num_traits::FromPrimitive;
+use printf::printf;
+
+/// Direct mapping of raylib's log levels
+/// See: https://github.com/raysan5/raylib/blob/d875891a3c2621ab40733ca3569eca9e054a6506/parser/raylib_api.json#L985-L1026
+#[derive(FromPrimitive)]
+enum RaylibLogLevel {
+    All = 0,
+    Trace = 1,
+    Debug = 2,
+    Info = 3,
+    Warning = 4,
+    Error = 5,
+    Fatal = 6,
+    None = 7,
+}
+
+/// Logging callback that is passed through to raylib over the ffi boundary.
+#[no_mangle]
+pub unsafe extern "C" fn log_callback(
+    level: i32,
+    message: *const i8,
+    args: *mut crate::ffi::__va_list_tag,
+) {
+    // Get the message as a string. This is calling back to C code with a reasonably safe sprintf implementation.
+    let formatted_message = printf(message, args as *mut c_void);
+
+    // Handle the log level and fall back on info!
+    match RaylibLogLevel::from_u32(level.try_into().unwrap()) {
+        Some(level) => match level {
+            RaylibLogLevel::Trace => log::trace!("{}", formatted_message),
+            RaylibLogLevel::Debug => log::debug!("{}", formatted_message),
+            RaylibLogLevel::Warning => log::warn!("{}", formatted_message),
+            RaylibLogLevel::Error => log::error!("{}", formatted_message),
+            RaylibLogLevel::Fatal => log::error!("{}", formatted_message),
+            _ => log::info!("{}", formatted_message),
+        },
+        None => {
+            log::info!("{}", formatted_message)
+        }
+    }
+}

--- a/raylib/src/core/log_hooks.rs
+++ b/raylib/src/core/log_hooks.rs
@@ -20,6 +20,7 @@ enum RaylibLogLevel {
 }
 
 /// Logging callback that is passed through to raylib over the ffi boundary.
+#[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn log_callback(
     level: i32,

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -209,11 +209,11 @@ fn init_window(width: i32, height: i32, title: &str, use_log_crate: bool) -> Ray
         panic!("Attempted to initialize raylib-rs more than once!");
     } else {
         unsafe {
-            let c_title = CString::new(title).unwrap();
-            ffi::InitWindow(width, height, c_title.as_ptr());
             if use_log_crate {
                 ffi::SetTraceLogCallback(Some(log_hooks::log_callback));
             }
+            let c_title = CString::new(title).unwrap();
+            ffi::InitWindow(width, height, c_title.as_ptr());
         }
         if !unsafe { ffi::IsWindowReady() } {
             panic!("Attempting to create window failed!");

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -209,6 +209,7 @@ fn init_window(width: i32, height: i32, title: &str, use_log_crate: bool) -> Ray
         panic!("Attempted to initialize raylib-rs more than once!");
     } else {
         unsafe {
+            #[cfg(target_os = "linux")]
             if use_log_crate {
                 ffi::SetTraceLogCallback(Some(log_hooks::log_callback));
             }

--- a/raylib/src/core/mod.rs
+++ b/raylib/src/core/mod.rs
@@ -18,6 +18,7 @@ pub mod text;
 pub mod texture;
 pub mod vr;
 pub mod window;
+mod log_hooks;
 
 use crate::ffi;
 use std::ffi::CString;
@@ -82,6 +83,7 @@ pub struct RaylibBuilder {
     width: i32,
     height: i32,
     title: String,
+    using_log_crate: bool
 }
 
 /// Creates a `RaylibBuilder` for choosing window options before initialization.
@@ -156,6 +158,12 @@ impl RaylibBuilder {
         self
     }
 
+    /// Switches the internal logger to use the `log` crate
+    pub fn replace_logger(&mut self) -> &mut Self {
+        self.using_log_crate = true;
+        self
+    }
+
     /// Builds and initializes a Raylib window.
     ///
     /// # Panics
@@ -186,7 +194,7 @@ impl RaylibBuilder {
         unsafe {
             ffi::SetConfigFlags(flags as u32);
         }
-        let rl = init_window(self.width, self.height, &self.title);
+        let rl = init_window(self.width, self.height, &self.title, self.using_log_crate);
         (rl, RaylibThread(PhantomData))
     }
 }
@@ -196,13 +204,16 @@ impl RaylibBuilder {
 /// # Panics
 ///
 /// Attempting to initialize Raylib more than once will result in a panic.
-fn init_window(width: i32, height: i32, title: &str) -> RaylibHandle {
+fn init_window(width: i32, height: i32, title: &str, use_log_crate: bool) -> RaylibHandle {
     if IS_INITIALIZED.load(Ordering::Relaxed) {
         panic!("Attempted to initialize raylib-rs more than once!");
     } else {
         unsafe {
             let c_title = CString::new(title).unwrap();
             ffi::InitWindow(width, height, c_title.as_ptr());
+            if use_log_crate {
+                ffi::SetTraceLogCallback(Some(log_hooks::log_callback));
+            }
         }
         if !unsafe { ffi::IsWindowReady() } {
             panic!("Attempting to create window failed!");

--- a/raylib/src/lib.rs
+++ b/raylib/src/lib.rs
@@ -74,6 +74,9 @@ pub use crate::core::logging::*;
 pub use crate::core::misc::{get_random_value, open_url};
 pub use crate::core::*;
 
+#[macro_use]
+extern crate num_derive;
+
 // Re-exports
 #[cfg(feature = "with_serde")]
 pub use serde;


### PR DESCRIPTION
This fixes #94, and supersedes #95

There is no need to link extra C code for replacing the internal logger when Rust is FFI-compatible in *both* directions.

This PR adds a new function (`RaylibBuilder::replace_logger()`) that, when called, will redirect all raylib log messages through calls to the [`log`](https://crates.io/crates/log) crate. In my particular use case, I am using this to further pass through Tokio's [`tracing`](https://crates.io/crates/tracing) crate, but it can be really used for anything. 

## Limitations

For now, I have artificially limited this (with a `cfg` macro) to only happen on Linux (it will just silently *not* replace the logger on other platforms) due to MSVC throwing a fit about `__va_list_tag` not existing (presumably since `stdarg.h` doesn't seem to be standard across compilers). I don't *currently* have the time to debug this on windows, and don't have the resources to compile it on macos.

---

This is the first of a small handful of PRs you will see from me, since it is the weekend of Ludum Dare 49, and my team is once again building our entry with this crate.

It also happens to be the month of hacktoberfest. I would appreciate if you could tag this PR as `hacktoberfest-accepted` weather or not it gets merged so it can count towards my total. More info on hacktoberfest can be found [here](https://hacktoberfest.digitalocean.com/).
