### PR TITLE
Upddate the README to point users to the git version of this crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Follow instructions for building raylib for your platform [here](https://github.
 
 ```toml
 [dependencies]
-raylib = "3.5"
+raylib = { version = "3.5", git = "https://github.com/deltaphc/raylib-rs" }
 ```
 
 2. Start coding!


### PR DESCRIPTION
Since the crates.io publishes seem to lag behind `master`, I have changed the README to just point to git in the "how to use" section. 

This way, you should stop getting issues about things that have already been fixed.

---

This is another of a small handful of PRs you will see from me, since it is the weekend of Ludum Dare 49, and my team is once again building our entry with this crate.

It also happens to be the month of hacktoberfest. I would appreciate if you could tag this PR as `hacktoberfest-accepted` weather or not it gets merged so it can count towards my total. More info on hacktoberfest can be found [here](https://hacktoberfest.digitalocean.com/).
