### PR TITLE
Add safety check to Vector2 normalization

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -189,12 +189,16 @@ impl Vector2 {
 
     /// Normalizes the vector.
     pub fn normalize(&mut self) {
-        *self /= self.length();
+        *self = self.normalized();
     }
 
     /// Returns a new `Vector2` with normalized components from the current vector.
     pub fn normalized(&self) -> Vector2 {
-        *self / self.length()
+        let length_sqr = self.length_sqr();
+        if length_sqr == 0.0 {
+            return *self;
+        }
+        *self / length_sqr.sqrt()
     }
 
     /// Returns a new `Vector2` with componenets linearly interpolated by `amount` towards vector `v`.


### PR DESCRIPTION
Handles normalizing vector2 of zero length. Before that it resulted in `(Nan, Nan)`.
It was done for Vector3, so it makes sense for Vector2 to work the same.
Getting the squared length and then doing the square root if needed is probably the most optimal way.
Returns unchanged self (`Vector2 (0,0)`) because there is no need to do any more operations.
Raylib also does [this check](https://github.com/raysan5/raylib/blob/master/src/raymath.h#L323).
(It isn't the same code but should produce same results and be marginally faster)