### PR TITLE
Pin to the exact version of raylib-sys

### DIFF
--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "game-engines", "graphics"]
 edition = "2018"
 
 [dependencies]
-raylib-sys = { version = "3.7", path = "../raylib-sys" }
+raylib-sys = { version = "= 3.7.0", path = "../raylib-sys" }
 libc = "0.2.45"
 lazy_static = "1.2.0"
 cfg-if = "1.0.0"


### PR DESCRIPTION
I ran into a confusing scenario when upgrading to 3.7 from 3.5 which seems to be caused by the current versioning scheme not following [semver](https://semver.org/). [More details here](https://users.rust-lang.org/t/is-cargo-intended-to-act-this-way-or-it-a-bug/70237/5).

Now, having the version number intuitively matching the C Raylib's version number is worth something, and my scenario seems to be rare, so I'm not necessarily suggesting that the version numbering should be changed. But as I understand it, if the `raylib` crate specifies the exact version of `raylib-sys` to use, then at least part of the confusing situation would have been avoided. And pinning the raylib version in my `Cargo.toml` would have worked, without needing to specify `raylib-sys` explicitly. This seems like an improvement worth making, to me.