### PR TITLE
Vector2 Constants

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -176,7 +176,7 @@ impl Vector2 {
     pub const fn one() -> Vector2 {
         Vector2 { x: 1.0, y: 1.0 }
     }
-   
+
     /// Calculates the vector length.
     pub fn length(&self) -> f32 {
         ((self.x * self.x) + (self.y * self.y)).sqrt()

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -165,6 +165,18 @@ impl Vector2 {
         Vector2 { x, y }
     }
 
+    /// Returns a new `Vector2` with both components set to zero.
+    #[inline]
+    pub const fn zero() -> Vector2 {
+        Vector2 { x: 0.0, y: 0.0 }
+    }
+
+    /// Returns a new `Vector2` with both components set to one.
+    #[inline]
+    pub const fn one() -> Vector2 {
+        Vector2 { x: 1.0, y: 1.0 }
+    }
+   
     /// Calculates the vector length.
     pub fn length(&self) -> f32 {
         ((self.x * self.x) + (self.y * self.y)).sqrt()

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -154,19 +154,15 @@ pub fn rrect<T1: AsF32, T2: AsF32, T3: AsF32, T4: AsF32>(
 }
 
 impl Vector2 {
+    /// Constant `Vector2` with both components set to zero.
+    const ZERO: Vector2 = Vector2 { x: 0.0, y: 0.0 };
+
+    /// Constant `Vector2` with both components set to one.
+    const ONE: Vector2 = Vector2 { x: 1.0, y: 1.0 };
+    
     /// Returns a new `Vector2` with specified components.
     pub const fn new(x: f32, y: f32) -> Vector2 {
         Vector2 { x, y }
-    }
-
-    /// Returns a new `Vector2` with both components set to zero.
-    pub fn zero() -> Vector2 {
-        Vector2 { x: 0.0, y: 0.0 }
-    }
-
-    /// Returns a new `Vector2` with both components set to one.
-    pub fn one() -> Vector2 {
-        Vector2 { x: 1.0, y: 1.0 }
     }
 
     /// Calculates the vector length.


### PR DESCRIPTION
- removed `zero()` and `one()` functions
- added constant definitions for zero and one

These functions can be swapped out for constant definitions since they always return the same value.
Alternatively, these can also be changed to const/inline functions.