### PR TITLE
Fix serde support for color.rs and window.rs

### DIFF
--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -1,6 +1,8 @@
 //! [`Color`] manipulation helpers
 use crate::core::math::{Vector3, Vector4};
 use crate::ffi;
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -4,6 +4,8 @@ use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::{CStr, CString, IntoStringError, NulError};
 use std::os::raw::c_char;
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 // MonitorInfo grabs the sizes (virtual and physical) of your monitor
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Add `#[cfg(feature = "serde")] use serde::{Serialize, Deserialize};` to color.rs and window.rs to fix serde support