### PR TITLE
Updated example as per API change in `rand` crate

### DIFF
--- a/samples/3d_camera_first_person.rs
+++ b/samples/3d_camera_first_person.rs
@@ -14,13 +14,13 @@ struct Column {
 impl Column {
     fn create_random() -> Column {
         let mut rng = rand::thread_rng();
-        let height: f32 = rng.gen_range(1.0, 12.0);
+        let height: f32 = rng.gen_range(1.0..12.0);
         let position = Vector3::new(
-            rng.gen_range(-15.0, 15.0),
+            rng.gen_range(-15.0..15.0),
             height / 2.0,
-            rng.gen_range(-15.0, 15.0),
+            rng.gen_range(-15.0..15.0),
         );
-        let color = Color::new(rng.gen_range(20, 255), rng.gen_range(10, 55), 30, 255);
+        let color = Color::new(rng.gen_range(20..255), rng.gen_range(10..55), 30, 255);
 
         Column {
             height,


### PR DESCRIPTION
`gen_range()` now requires a single parameter `Range` rather than two ints