### PR TITLE
Add missing linked libraries for RPI support

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -188,7 +188,13 @@ fn link(platform: Platform, platform_os: PlatformOS) {
     }
     if platform == Platform::Web {
         println!("cargo:rustc-link-lib=glfw");
-    }
+    } else if platform == Platform::RPI {
+        println!("cargo:rustc-link-search=/opt/vc/lib");
+        println!("cargo:rustc-link-lib=bcm_host");
+        println!("cargo:rustc-link-lib=brcmEGL");
+        println!("cargo:rustc-link-lib=brcmGLESv2");
+        println!("cargo:rustc-link-lib=vcos");
+   }
 
     println!("cargo:rustc-link-lib=static=raylib");
 }


### PR DESCRIPTION
In accordance with https://github.com/deltaphc/raylib-rs/issues/11