### PR TITLE
Wayland Support + Forcing OpenGL Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,20 @@ fn main() {
 - In C, `LoadFontData` returns a pointer to a heap-allocated array of `CharInfo` structs. In this Rust binding, said array is copied into an owned `Vec<CharInfo>`, the original data is freed, and the owned Vec is returned.
 - In C, `GetDroppedFiles` returns a pointer to an array of strings owned by raylib. Again, for safety and also ease of use, this binding copies said array into a `Vec<String>` which is returned to the caller.
 - I've tried to make linking automatic, though I've only tested on Windows 10, Ubuntu, and MacOS 15. Other platforms may have other considerations.
+- OpenGL 3.3, 2.1, and ES 2.0 may be forced via adding `["opengl_33"]`, `["opengl_21"]` or `["opengl_es_20]` to the `features` array in your Cargo.toml dependency definition.
 
 ## Building from source
 
 1. Clone repository: `git clone --recurse-submodules`
 2. `cargo build`
+
+### If building for Wayland on Linux
+
+3. Install these packages:  
+`libglfw3-dev wayland-devel libxkbcommon-devel wayland-protocols wayland-protocols-devel libecm-dev`
+###### Note that this may not be a comprehensive list, please add details for your distribution or expand on these packages if you believe this to be incomplete.
+
+4. Enable wayland by adding `features=["wayland"]` to your dependency defenition
 
 ## Cross-compiling using `cross`
 

--- a/raylib-sys/Cargo.toml
+++ b/raylib-sys/Cargo.toml
@@ -25,3 +25,12 @@ cc = "1.0"
 default = []
 # Build Raylib headless for docs. Up to you to link
 nobuild = []
+
+# Build for wayland on linux. Should fix #119
+wayland = []
+
+# OpenGL stuff, intended for fixing #122
+opengl_33 = []
+opengl_21 = []
+# opengl_11 = [] I couldn't get this one working, the others were fine in my limited testing (unsure about wayland compatibility)
+opengl_es_20 = []

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -62,6 +62,42 @@ fn build_with_cmake(src_path: &str) {
         // turn off until this is fixed
         .define("SUPPORT_BUSY_WAIT_LOOP", "OFF");
 
+    // Enable wayland cmake flag if feature is specified
+    #[cfg(feature = "wayland")]
+    {
+        builder.define("USE_WAYLAND", "ON");
+        builder.define("USE_EXTERNAL_GLFW", "ON"); // Necessary for wayland support in my testing
+    }
+
+    // This seems redundant, but I felt it was needed incase raylib changes it's default
+    #[cfg(not(feature = "wayland"))]
+    builder.define("USE_WAYLAND", "OFF");
+    
+    // Scope implementing flags for forcing OpenGL version
+    // See all possible flags at https://github.com/raysan5/raylib/wiki/CMake-Build-Options
+    {
+        #[cfg(feature = "opengl_33")]
+        builder.define("OPENGL_VERSION", "3.3");
+
+        #[cfg(feature = "opengl_21")]
+        builder.define("OPENGL_VERSION", "2.1");
+
+        // #[cfg(feature = "opengl_11")]
+        // builder.define("OPENGL_VERSION", "1.1");
+
+        #[cfg(feature = "opengl_es_20")]
+        builder.define("OPENGL_VERSION", "ES 2.0");
+
+        // Once again felt this was necessary incase a default was changed :)
+        #[cfg(not(any(
+            feature = "opengl_33",
+            feature = "opengl_21",
+            // feature = "opengl_11",
+            feature = "opengl_es_20"
+        )))]
+        builder.define("OPENGL_VERSION", "OFF");
+    }
+
     match platform {
         Platform::Desktop => conf.define("PLATFORM", "Desktop"),
         Platform::Web => conf.define("PLATFORM", "Web"),
@@ -173,8 +209,20 @@ fn link(platform: Platform, platform_os: PlatformOS) {
             println!("cargo:rustc-link-lib=dylib=shell32");
         }
         PlatformOS::Linux => {
-            println!("cargo:rustc-link-search=/usr/local/lib");
-            println!("cargo:rustc-link-lib=X11");
+            // X11 linking
+            #[cfg(not(feature = "wayland"))]
+            {
+                println!("cargo:rustc-link-search=/usr/local/lib");
+                println!("cargo:rustc-link-lib=X11");
+            }
+
+            // Wayland linking
+            #[cfg(feature = "wayland")]
+            {
+                println!("cargo:rustc-link-search=/usr/local/lib");
+                println!("cargo:rustc-link-lib=wayland-client");
+                println!("cargo:rustc-link-lib=glfw"); // Link against locally installed glfw
+            }
         }
         PlatformOS::OSX => {
             println!("cargo:rustc-link-search=native=/usr/local/lib");


### PR DESCRIPTION
Adds support for wayland (did not work without linking to local glfw) for https://github.com/deltaphc/raylib-rs/issues/119

Adds ability to force OpenGL version to 3.3, 2.1, or ES 2.0 (I couldn't get 1.1 working if anyone wanted to take a stab at that) for https://github.com/deltaphc/raylib-rs/issues/90 and https://github.com/deltaphc/raylib-rs/issues/122

Also changed the README to accommodate for changes