### PR TITLE
simplify load_image_from_mem function

### DIFF
--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -298,7 +298,7 @@ fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
         // make sure cmake knows that it should bundle glfw in
         env::set_var(
             "EMCC_CFLAGS",
-            "-sUSE_GLFW=3 -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
+            "-sUSE_GLFW=3 -sGL_ENABLE_GET_PROC_ADDRESS -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
         );
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {

--- a/raylib-sys/build.rs
+++ b/raylib-sys/build.rs
@@ -72,7 +72,7 @@ fn build_with_cmake(src_path: &str) {
     // This seems redundant, but I felt it was needed incase raylib changes it's default
     #[cfg(not(feature = "wayland"))]
     builder.define("USE_WAYLAND", "OFF");
-    
+
     // Scope implementing flags for forcing OpenGL version
     // See all possible flags at https://github.com/raysan5/raylib/wiki/CMake-Build-Options
     {
@@ -242,7 +242,7 @@ fn link(platform: Platform, platform_os: PlatformOS) {
         println!("cargo:rustc-link-lib=brcmEGL");
         println!("cargo:rustc-link-lib=brcmGLESv2");
         println!("cargo:rustc-link-lib=vcos");
-   }
+    }
 
     println!("cargo:rustc-link-lib=static=raylib");
 }
@@ -296,8 +296,10 @@ fn run_command(cmd: &str, args: &[&str]) {
 fn platform_from_target(target: &str) -> (Platform, PlatformOS) {
     let platform = if target.contains("wasm32") {
         // make sure cmake knows that it should bundle glfw in
-        // Cargo web takes care of this but better safe than sorry
-        env::set_var("EMMAKEN_CFLAGS", "-s USE_GLFW=3");
+        env::set_var(
+            "EMCC_CFLAGS",
+            "-sUSE_GLFW=3 -sWASM=1 -sALLOW_MEMORY_GROWTH=1 -sWASM_MEM_MAX=512MB -sTOTAL_MEMORY=512MB -sABORTING_MALLOC=0 -sASYNCIFY -sFORCE_FILESYSTEM=1 -sASSERTIONS=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -sEXPORTED_FUNCTIONS=['_malloc''_free''_main''_emsc_main''_emsc_set_window_size'] -sEXPORTED_RUNTIME_METHODS=ccallcwrap",
+        );
         Platform::Web
     } else if target.contains("armv7-unknown-linux") {
         Platform::RPI

--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1072,13 +1072,13 @@ impl Quaternion {
     }
 
     /// Returns a quaternion equivalent to Euler angles.
-    pub fn from_euler(roll: f32, pitch: f32, yaw: f32) -> Quaternion {
-        let x0 = (roll * 0.5).cos();
-        let x1 = (roll * 0.5).sin();
-        let y0 = (pitch * 0.5).cos();
-        let y1 = (pitch * 0.5).sin();
-        let z0 = (yaw * 0.5).cos();
-        let z1 = (yaw * 0.5).sin();
+    pub fn from_euler(pitch: f32, yaw: f32, roll: f32) -> Quaternion {
+        let x0 = (pitch * 0.5).cos();
+        let x1 = (pitch * 0.5).sin();
+        let y0 = (yaw * 0.5).cos();
+        let y1 = (yaw * 0.5).sin();
+        let z0 = (roll * 0.5).cos();
+        let z1 = (roll * 0.5).sin();
 
         Quaternion {
             x: (x1 * y0 * z0) - (x0 * y1 * z1),

--- a/raylib/src/core/text.rs
+++ b/raylib/src/core/text.rs
@@ -152,7 +152,45 @@ impl RaylibHandle {
         }
         Ok(Font(f))
     }
-
+    /// Load font data from a given memory buffer.
+    /// `file_type` refers to the extension, e.g. ".ttf".
+    #[inline]
+    pub fn load_font_from_memory(
+        &mut self,
+        _: &RaylibThread,
+        file_type: &str,
+        file_data: &[u8],
+        font_size: i32,
+        chars: FontLoadEx,
+    ) -> Result<Font, String> {
+        let c_file_type = CString::new(file_type).unwrap();
+        let f = unsafe {
+            match chars {
+                FontLoadEx::Chars(c) => ffi::LoadFontFromMemory(
+                    c_file_type.as_ptr(),
+                    file_data.as_ptr(),
+                    file_data.len() as i32,
+                    font_size,
+                    c.as_ptr() as *mut i32,
+                    c.len() as i32,
+                ),
+                FontLoadEx::Default(count) => ffi::LoadFontFromMemory(
+                    c_file_type.as_ptr(),
+                    file_data.as_ptr(),
+                    file_data.len() as i32,
+                    font_size,
+                    std::ptr::null_mut(),
+                    count,
+                ),
+            }
+        };
+        if f.chars.is_null() || f.texture.id == 0 {
+            return Err(format!(
+                "Error loading font from memory. Is it the right type?"
+            ));
+        }
+        Ok(Font(f))
+    }
     /// Loads font data for further use (see also `Font::from_data`).
     /// Now supports .tiff
     #[inline]

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -3,6 +3,7 @@ use crate::core::color::Color;
 use crate::core::math::{Rectangle, Vector4};
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
+use std::convert::TryInto;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
 
@@ -693,12 +694,17 @@ impl Image {
         Ok(Image(i))
     }
 
-    /// Loads image from a given memory buffer as a vector of arrays
+    /// Loads image from a given memory buffer
     /// ensure filetype is extension, for example, ".png"
-    pub fn load_image_from_mem(filetype: &str, bytes: &Vec<u8>, size: i32) -> Result<Image, String> {
+    pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, String> {
         let c_filetype = CString::new(filetype).unwrap();
-        let c_bytes = bytes.as_ptr();
-        let i = unsafe { ffi::LoadImageFromMemory(c_filetype.as_ptr(), c_bytes, size) };
+        let i = unsafe {
+            ffi::LoadImageFromMemory(
+                c_filetype.as_ptr(),
+                bytes.as_ptr(),
+                bytes.len().try_into().unwrap(),
+            )
+        };
         if i.data.is_null() {
             return Err(format!(
             "Image data is null. Check provided buffer data"

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -695,7 +695,8 @@ impl Image {
     }
 
     /// Loads image from a given memory buffer
-    /// ensure filetype is extension, for example, ".png"
+    /// The input data is expected to be in a supported file format such as png. Which formats are
+    /// supported depend on the build flags used for the raylib (C) library.
     pub fn load_image_from_mem(filetype: &str, bytes: &[u8]) -> Result<Image, String> {
         let c_filetype = CString::new(filetype).unwrap();
         let i = unsafe {


### PR DESCRIPTION
A simple but nice to have change to Image::load_image_from_mem:
 - Pass the data buffer in as a slice instead of a Vec. We don't really need the vector's functionality here, so we shouldn't force the user to create one (also mentioned in #106).
 - Remove the size parameter, we can get the size from the slice/vector.

Points of consideration:
 - Use `try_into` when converting the buffer's size into a i32. Using `try_into().unwrap()` would panic when the buffers size exceeds i32's range. That doesn't sound very likely, but I think it's better to have the crash happen here, rather than leave raylib to deal with a negative size.

Note. I'm new to Rust as a language so I'm not sure if this is 100% right, feel free to yell at me if this code makes no sense :)