### PR TITLE
Expose wayland feature and fix u32 conversion issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fn main() {
 `libglfw3-dev wayland-devel libxkbcommon-devel wayland-protocols wayland-protocols-devel libecm-dev`
 ###### Note that this may not be a comprehensive list, please add details for your distribution or expand on these packages if you believe this to be incomplete.
 
-4. Enable wayland by adding `features=["wayland"]` to your dependency defenition
+4. Enable wayland by adding `features=["wayland"]` to your dependency definition
 
 ## Cross-compiling using `cross`
 

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -19,13 +19,13 @@ cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
-wayland = ["raylib-sys/wayland"]
 
 [features]
 nightly = []
 nobuild = ["raylib-sys/nobuild"]
 with_serde = ["serde", "serde_json"]
 nalgebra_interop = ["nalgebra"]
+wayland = ["raylib-sys/wayland"]
 
 [package.metadata.docs.rs]
 features = ["nobuild"]

--- a/raylib/Cargo.toml
+++ b/raylib/Cargo.toml
@@ -19,6 +19,7 @@ cfg-if = "1.0.0"
 serde = { version = "1.0.125", features = ["derive"], optional = true }
 serde_json = { version = "1.0.64", optional = true }
 nalgebra = { version = "0.26", optional = true }
+wayland = ["raylib-sys/wayland"]
 
 [features]
 nightly = []

--- a/raylib/src/core/input.rs
+++ b/raylib/src/core/input.rs
@@ -56,7 +56,7 @@ impl RaylibHandle {
     pub fn get_char_pressed(&mut self) -> Option<char> {
         let char_code = unsafe { ffi::GetCharPressed() };
         if char_code > 0 {
-            return char::from_u32(char_code as i32);
+            return char::from_u32(char_code as u32);
         }
         None
     }


### PR DESCRIPTION
This enables setting the wayland feature in your Cargo.toml file:
```
[dependencies]
raylib = { ..., features = ["wayland"] }
```

Also it fixes the latest build issue ( https://github.com/deltaphc/raylib-rs/actions/runs/2547187213 )