### PR TITLE
Clean up warnings during compilation

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -184,7 +184,7 @@ impl Vector2 {
 
     /// Calculates the vector length square (**2);
     pub fn length_sqr(&self) -> f32 {
-        ((self.x * self.x) + (self.y * self.y))
+        (self.x * self.x) + (self.y * self.y)
     }
 
     /// Calculates the dot product with vector `v`.

--- a/raylib/src/core/texture.rs
+++ b/raylib/src/core/texture.rs
@@ -1,6 +1,6 @@
 //! Image and texture related functions
 use crate::core::color::Color;
-use crate::core::math::{Rectangle, Vector4};
+use crate::core::math::Rectangle;
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
 use std::ffi::CString;

--- a/raylib/src/core/vr.rs
+++ b/raylib/src/core/vr.rs
@@ -1,8 +1,6 @@
 //! Vr related functions
-use crate::core::camera::Camera3D;
 use crate::core::{RaylibHandle, RaylibThread};
 use crate::ffi;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 make_thin_wrapper!(
     VrStereoConfig,

--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -555,7 +555,7 @@ impl RaylibHandle {
 
     /// Get the window config state
     pub fn get_window_state(&self) -> WindowState {
-        let mut state = WindowState::default();
+        let state = WindowState::default();
         unsafe {
             if ffi::IsWindowState(ffi::ConfigFlags::FLAG_VSYNC_HINT as u32) {
                 state.set_vsync_hint(true);

--- a/samples/Cargo.toml
+++ b/samples/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/deltaphc/raylib-rs"
 raylib = { version = "3.7", path = "../raylib" }
 structopt = "0.2"
 specs-derive = "0.4.1"
-rand = "0.7"
+rand = "0.8"
 tcod = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/drop.rs
+++ b/samples/drop.rs
@@ -15,9 +15,9 @@ fn main() {
 }
 
 fn test_rslice(opt: &options::Opt) {
-    let (mut rl, thread) = opt.open_window("Drop Allocs");
+    let (mut _rl, _thread) = opt.open_window("Drop Allocs");
     let img = Image::gen_image_color(256, 256, Color::RED);
-    let pallet = img.extract_palette(16);
+    let _pallet = img.extract_palette(16);
 }
 
 /// Checks that shader files are droppable after window is closed

--- a/samples/roguelike.rs
+++ b/samples/roguelike.rs
@@ -589,10 +589,10 @@ fn make_map(objects: &mut Vec<Object>, level: u32) -> Map {
 
     let mut rooms = vec![];
     for _ in 0..MAX_ROOMS {
-        let w = rand::thread_rng().gen_range(ROOM_MIN_SIZE, ROOM_MAX_SIZE + 1);
-        let h = rand::thread_rng().gen_range(ROOM_MIN_SIZE, ROOM_MAX_SIZE + 1);
-        let x = rand::thread_rng().gen_range(0, MAP_WIDTH - w);
-        let y = rand::thread_rng().gen_range(0, MAP_HEIGHT - h);
+        let w = rand::thread_rng().gen_range(ROOM_MIN_SIZE..ROOM_MAX_SIZE + 1);
+        let h = rand::thread_rng().gen_range(ROOM_MIN_SIZE..ROOM_MAX_SIZE + 1);
+        let x = rand::thread_rng().gen_range(0..MAP_WIDTH - w);
+        let y = rand::thread_rng().gen_range(0..MAP_HEIGHT - h);
 
         let new_room = Rectangle::new(x as f32, y as f32, w as f32, h as f32);
         let failed = rooms
@@ -646,11 +646,11 @@ fn place_objects(room: Rectangle, map: &Map, objects: &mut Vec<Object>, level: u
     );
 
     // choose random number of monsters
-    let num_monsters = rand::thread_rng().gen_range(0, max_monsters + 1);
+    let num_monsters = rand::thread_rng().gen_range(0..max_monsters + 1);
 
     for _ in 0..num_monsters {
-        let x = rand::thread_rng().gen_range(room.x + 1.0, room.x + room.width) as i32;
-        let y = rand::thread_rng().gen_range(room.y + 1.0, room.y + room.height) as i32;
+        let x = rand::thread_rng().gen_range(room.x + 1.0..room.x + room.width) as i32;
+        let y = rand::thread_rng().gen_range(room.y + 1.0..room.y + room.height) as i32;
 
         // monster random table
         let troll_chance = from_dungeon_level(
@@ -767,11 +767,11 @@ fn place_objects(room: Rectangle, map: &Map, objects: &mut Vec<Object>, level: u
     ];
 
     // choose random number of items
-    let num_items = rand::thread_rng().gen_range(0, max_items + 1);
+    let num_items = rand::thread_rng().gen_range(0..max_items + 1);
     for _ in 0..num_items {
         // choose random spot for this item
-        let x = rand::thread_rng().gen_range(room.x as i32 + 1, (room.x + room.width) as i32);
-        let y = rand::thread_rng().gen_range(room.y as i32 + 1, (room.y + room.height) as i32);
+        let x = rand::thread_rng().gen_range(room.x as i32 + 1..(room.x + room.width) as i32);
+        let y = rand::thread_rng().gen_range(room.y as i32 + 1..(room.y + room.height) as i32);
 
         // only place it if the tile is not blocked
         if !is_blocked(x, y, map, objects) {
@@ -1411,8 +1411,8 @@ fn ai_confused(
         // move in a random direction, and decrease the number of turns confused
         move_by(
             monster_id,
-            rand::thread_rng().gen_range(-1, 2),
-            rand::thread_rng().gen_range(-1, 2),
+            rand::thread_rng().gen_range(-1..2),
+            rand::thread_rng().gen_range(-1..2),
             &game.map,
             objects,
         );

--- a/showcase/src/example/audio/audio_module_playing.rs
+++ b/showcase/src/example/audio/audio_module_playing.rs
@@ -16,11 +16,11 @@ const MAX_CIRCLES: usize = 64;
 #[derive(Default, Copy, Clone)]
 struct CircleWave
 {
-    position: Vector2 ,
+    position: Vector2,
      radius: f32,
      alpha: f32,
      speed: f32,
-    color: Color ,
+    color: Color,
 }
 
 pub fn run(rl
@@ -60,7 +60,6 @@ pub fn run(rl
 
     audio.play_music_stream(&mut music);
 
-    let mut timePlayed = 0.0;
     let mut pause = false;
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second
@@ -98,7 +97,7 @@ pub fn run(rl
         }
 
         // Get timePlayed scaled to bar dimensions
-        timePlayed = audio.get_music_time_played(&music) / audio.get_music_time_length(&music) * (screen_width - 40) as f32;
+        let time_played = audio.get_music_time_played(&music) / audio.get_music_time_length(&music) * (screen_width - 40) as f32;
 
         // Color circles animation
         for i in 0..MAX_CIRCLES 
@@ -137,7 +136,7 @@ pub fn run(rl
 
         // Draw time bar
         d.draw_rectangle(20, screen_height - 20 - 12, screen_width - 40, 12, Color::LIGHTGRAY);
-        d.draw_rectangle(20, screen_height - 20 - 12, timePlayed as i32, 12, Color::MAROON);
+        d.draw_rectangle(20, screen_height - 20 - 12, time_played as i32, 12, Color::MAROON);
         d.draw_rectangle_lines(20, screen_height - 20 - 12, screen_width - 40, 12, Color::GRAY);
 
         //----------------------------------------------------------------------------------

--- a/showcase/src/example/audio/audio_music_stream.rs
+++ b/showcase/src/example/audio/audio_music_stream.rs
@@ -27,7 +27,6 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
     audio.play_music_stream(&mut music);
 
-    let mut time_played = 0.0;
     let mut pause = false;
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second
@@ -58,7 +57,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         }
 
         // Get time_played scaled to bar dimensions (400 pixels)
-        time_played =
+        let time_played =
             audio.get_music_time_played(&music) / audio.get_music_time_length(&music) * 400.0;
 
         if time_played > 400.0 {

--- a/showcase/src/example/audio/audio_raw_stream.rs
+++ b/showcase/src/example/audio/audio_raw_stream.rs
@@ -38,9 +38,6 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
     audio.play_audio_stream(&mut stream); // Start processing stream buffer (no data loaded currently)
 
-    // Position read in to determine next frequency
-    let mut mousePosition = rvec2(-100.0, -100.0);
-
     // Cycles per second (hz)
     let mut frequency = 440.0;
 
@@ -66,11 +63,11 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         //----------------------------------------------------------------------------------
 
         // Sample mouse input.
-        mousePosition = rl.get_mouse_position();
+        let mouse_position = rl.get_mouse_position();
 
         if rl.is_mouse_button_down(raylib::consts::MouseButton::MOUSE_LEFT_BUTTON)
         {
-            let fp = mousePosition.y;
+            let fp = mouse_position.y;
             frequency = 40.0 + fp;
         }
 
@@ -121,7 +118,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
                 }
 
                 // Write the slice
-                &mut writeBuf[writeCursor..writeCursor+writeLength].copy_from_slice(&data[readCursor..readCursor+writeLength]);
+                let _ = &mut writeBuf[writeCursor..writeCursor+writeLength].copy_from_slice(&data[readCursor..readCursor+writeLength]);
                 // memcpy(writeBuf + writeCursor, data + readCursor, writeLength * sizeof(short));
 
                 // Update cursors and loop audio

--- a/showcase/src/example/controls_test_suite/controls_test_suite.rs
+++ b/showcase/src/example/controls_test_suite/controls_test_suite.rs
@@ -337,7 +337,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
                 d.get_screen_height(),
                 Color::RAYWHITE.fade(0.8),
             );
-            let itext = unsafe { d.gui_icon_text(RICON_FILE_SAVE, Some(rstr!("Save file as..."))) };
+            let itext = d.gui_icon_text(RICON_FILE_SAVE, Some(rstr!("Save file as...")));
             let itext = CString::new(itext).unwrap();
             let result = d.gui_text_input_box(
                 rrect(

--- a/showcase/src/example/core/core_2d_camera_platformer.rs
+++ b/showcase/src/example/core/core_2d_camera_platformer.rs
@@ -71,7 +71,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     };
 
     // Store pointers to the multiple update camera functions
-    let mut camera_updaters = [
+    let camera_updaters = [
         update_camera_center,
         update_camera_center_inside_map,
         update_camera_center_smooth_follow,
@@ -81,7 +81,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
     let mut camera_option = 0;
 
-    let mut camera_description = [
+    let camera_description = [
         "Follow player center",
         "Follow player center, but clamp to map edges",
         "Follow player center; smoothed",

--- a/showcase/src/example/core/core_input_gestures.rs
+++ b/showcase/src/example/core/core_input_gestures.rs
@@ -23,14 +23,12 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     rl.set_window_size(screen_width, screen_height);
     rl.set_window_title(thread, "raylib [core] example - input gestures");
 
-    let mut touch_position = rvec2(0, 0);
     let touch_area = rrect(220, 10, screen_width - 230, screen_height - 20);
 
     let mut gestures_count = 0;
     let mut gesture_strings = [raylib::consts::Gestures::GESTURE_NONE; MAX_GESTURE_STRINGS];
 
     let mut current_gesture = GESTURE_NONE;
-    let mut last_gesture = GESTURE_NONE;
 
     //SetGesturesEnabled(0b0000000000001001);   // Enable only some gestures to be detected
 
@@ -43,9 +41,9 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     {
         // Update
         //----------------------------------------------------------------------------------
-        last_gesture = current_gesture;
+        let last_gesture = current_gesture;
         current_gesture = rl.get_gesture_detected();
-        touch_position = rl.get_touch_position(0);
+        let touch_position = rl.get_touch_position(0);
 
         if touch_area.check_collision_point_rec(touch_position) && (current_gesture != GESTURE_NONE)
         {

--- a/showcase/src/example/core/core_input_mouse.rs
+++ b/showcase/src/example/core/core_input_mouse.rs
@@ -20,8 +20,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     rl.set_window_size(screen_width, screen_height);
     rl.set_window_title(thread, "raylib [core] example - mouse input");
 
-    let mut ballPosition = rvec2(-100.0, -100.0);
-    let mut ballColor = Color::DARKBLUE;
+    let mut ball_color = Color::DARKBLUE;
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second
                            //---------------------------------------------------------------------------------------
@@ -32,22 +31,22 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     {
         // Update
         //----------------------------------------------------------------------------------
-        ballPosition = rl.get_mouse_position();
+        let ball_position = rl.get_mouse_position();
 
         if rl.is_mouse_button_pressed(raylib::consts::MouseButton::MOUSE_LEFT_BUTTON)
             {
 
-                ballColor = Color::MAROON;
+                ball_color = Color::MAROON;
             }
         else if rl.is_mouse_button_pressed(raylib::consts::MouseButton::MOUSE_MIDDLE_BUTTON)
             {
 
-                ballColor = Color::LIME;
+                ball_color = Color::LIME;
             }
         else if rl.is_mouse_button_pressed(raylib::consts::MouseButton::MOUSE_RIGHT_BUTTON)
             {
 
-                ballColor = Color::DARKBLUE;
+                ball_color = Color::DARKBLUE;
             }
         //----------------------------------------------------------------------------------
 
@@ -57,7 +56,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
         d.clear_background(Color::RAYWHITE);
 
-        d.draw_circle_v(ballPosition, 40.0, ballColor);
+        d.draw_circle_v(ball_position, 40.0, ball_color);
 
         d.draw_text("move ball with mouse and click mouse button to change color", 10, 10, 20, Color::DARKGRAY);
 

--- a/showcase/src/example/core/core_input_multitouch.rs
+++ b/showcase/src/example/core/core_input_multitouch.rs
@@ -24,11 +24,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     rl.set_window_size(screen_width, screen_height);
     rl.set_window_title(thread, "raylib [core] example - input multitouch");
 
-    let mut ball_position = rvec2(-100.0, -100.0);
-    let mut ball_color = Color::BEIGE;
-
     let mut touch_counter = 0;
-    let mut touch_position = Vector2::zero();
 
     rl.set_target_fps(60); // Set our game to run at 60 frames-per-second
                            //---------------------------------------------------------------------------------------
@@ -39,9 +35,8 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     {
         // Update
         //----------------------------------------------------------------------------------
-        ball_position = rl.get_mouse_position();
-
-        ball_color = Color::BEIGE;
+        let ball_position = rl.get_mouse_position();
+        let mut ball_color = Color::BEIGE;
 
         if rl.is_mouse_button_down(raylib::consts::MouseButton::MOUSE_LEFT_BUTTON)
             {
@@ -91,7 +86,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         // Multitouch
         for i in 0..MAX_TOUCH_POINTS
         {
-            touch_position = d.get_touch_position(i); // Get the touch point
+            let touch_position = d.get_touch_position(i); // Get the touch point
 
             if (touch_position.x >= 0.0) && (touch_position.y >= 0.0) // Make sure point is not (-1,-1 as this means there is no touch for it
             {

--- a/showcase/src/example/core/core_world_screen.rs
+++ b/showcase/src/example/core/core_world_screen.rs
@@ -29,7 +29,6 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     );
 
     let  cube_position = Vector3::zero();
-    let mut cube_screen_position = rvec2(0.0, 0.0);
 
     rl.set_camera_mode(&camera, raylib::consts::CameraMode::CAMERA_FREE); // Set a free camera mode
 
@@ -45,7 +44,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         rl.update_camera(&mut camera); // Update camera
 
         // Calculate cube screen space position (with a little offset to be in top)
-        cube_screen_position = rl.get_world_to_screen(rvec3(cube_position.x, cube_position.y + 2.5,  cube_position.z), camera);
+        let cube_screen_position = rl.get_world_to_screen(rvec3(cube_position.x, cube_position.y + 2.5,  cube_position.z), camera);
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/showcase/src/example/models/models_box_collisions.rs
+++ b/showcase/src/example/models/models_box_collisions.rs
@@ -22,19 +22,16 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
     rl.set_window_size(screen_width, screen_height);
 
     // Define the camera to look into our 3d world
-    let mut camera = Camera::perspective( rvec3( 0.0, 10.0, 10.0 ), rvec3( 0.0, 0.0, 0.0 ), rvec3( 0.0, 1.0, 0.0 ), 45.0 );
+    let camera = Camera::perspective( rvec3( 0.0, 10.0, 10.0 ), rvec3( 0.0, 0.0, 0.0 ), rvec3( 0.0, 1.0, 0.0 ), 45.0 );
 
     let mut playerPosition = rvec3( 0.0, 1.0, 2.0 );
     let playerSize = rvec3( 1.0, 2.0, 1.0 );
-    let mut playerColor = Color::GREEN;
 
     let enemyBoxPos = rvec3( -4.0, 1.0, 0.0 );
     let enemyBoxSize = rvec3( 2.0, 2.0, 2.0 );
 
     let enemySpherePos = rvec3( 4.0, 0.0, 0.0 );
     let enemySphereSize = 1.5;
-
-    let mut collision = false;
 
     rl.set_target_fps(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -51,7 +48,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
         else if (rl.is_key_down(raylib::consts::KeyboardKey::KEY_DOWN)) {playerPosition.z += 0.2;}
         else if (rl.is_key_down(raylib::consts::KeyboardKey::KEY_UP)){ playerPosition.z -= 0.2;}
 
-        collision = false;
+        let mut collision = false;
 
         // Check collisions player vs enemy-box
         if 
@@ -78,8 +75,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
                                      playerPosition.z + playerSize.z/2.0 )).check_collision_box_sphere(
             enemySpherePos, enemySphereSize) {collision = true;}
 
-        if (collision){ playerColor = Color::RED;}
-        else {playerColor = Color::GREEN;}
+        let playerColor = if collision { Color::RED } else { Color::GREEN };
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/showcase/src/example/models/models_first_person_maze.rs
+++ b/showcase/src/example/models/models_first_person_maze.rs
@@ -38,7 +38,6 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
     let mapPixels = imMap.get_image_data();
 
     let mapPosition = rvec3( -16.0, 0.0, -8.0 );  // Set model position
-    let playerPosition = camera.position;       // Set player position
 
     rl.set_camera_mode(&camera, raylib::consts::CameraMode::CAMERA_FIRST_PERSON);     // Set camera mode
 

--- a/showcase/src/example/models/models_geometric_shapes.rs
+++ b/showcase/src/example/models/models_geometric_shapes.rs
@@ -22,7 +22,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
     rl.set_window_size(screen_width, screen_height);
 
     // Define the camera to look into our 3d world
-    let mut camera = Camera3D::perspective(
+    let camera = Camera3D::perspective(
      rvec3( 0.0, 10.0,10.0 ),
     rvec3( 0.0, 0.0,0.0 ),
      rvec3( 0.0, 1.0,0.0 ),

--- a/showcase/src/example/models/models_mesh_picking.rs
+++ b/showcase/src/example/models/models_mesh_picking.rs
@@ -31,16 +31,12 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
      45.0,                                // Camera field-of-view Y
     );
 
-    let mut ray = Ray::default();        // Picking ray
-
    let mut tower  = rl.load_model(thread, "original/model/resources/models/turret.obj").unwrap();                 // Load OBJ model
     let texture = rl.load_texture(thread, "original/models/resources/models/turret_diffuse.png").unwrap(); // Load model texture
     tower.materials_mut()[0].maps_mut()[raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO as usize].texture = *texture.as_ref();                 // Set model diffuse texture
 
     let  towerPos = rvec3( 0.0, 0.0, 0.0 );                    // Set model position
     let  towerBBox = tower.meshes_mut()[0].mesh_bounding_box();   // Get mesh bounding box
-    let mut hitMeshBBox = false;
-    let mut hitTriangle = false;
 
     // Test triangle
     let ta = rvec3( -25.0, 0.5,0.0 );
@@ -69,7 +65,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
         let mut cursorColor = Color::WHITE;
 
         // Get ray and test against ground, triangle, and mesh
-        ray = rl.get_mouse_ray(rl.get_mouse_position(), camera);
+        let ray = rl.get_mouse_ray(rl.get_mouse_position(), camera);
 
         // Check ray collision aginst ground plane
         let groundHitInfo = get_collision_ray_ground(ray, 0.0);
@@ -84,6 +80,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
         // Check ray collision against test triangle
         let triHitInfo = get_collision_ray_triangle(ray, ta, tb, tc);
 
+        let hitTriangle;
         if ((triHitInfo.hit) && (triHitInfo.distance < nearestHit.distance))
         {
             nearestHit = triHitInfo;
@@ -95,9 +92,10 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
         }
         else {hitTriangle = false;}
 
-        let mut  meshHitInfo = RayHitInfo::default();
+        let meshHitInfo;
 
         // Check ray collision against bounding box first, before trying the full ray-mesh test
+        let hitMeshBBox;
         if (towerBBox.check_collision_ray_box(ray))
         {
             hitMeshBBox = true;
@@ -112,9 +110,9 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
                 cursorColor = Color::ORANGE;
                 hitObjectName = "Mesh";
             }
+        } else {
+            hitMeshBBox = false; // <- ???
         }
-
-        hitMeshBBox = false;
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/showcase/src/example/models/models_waving_cubes.rs
+++ b/showcase/src/example/models/models_waving_cubes.rs
@@ -49,7 +49,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
         let scale = 2.0 + time.sin()*0.7;
 
         // Move camera around the scene
-        let mut cameraTime = time*0.3;
+        let cameraTime = time*0.3;
         camera.position.x = (cameraTime).cos()*40.0;
         camera.position.z = (cameraTime).sin()*40.0;
         //----------------------------------------------------------------------------------

--- a/showcase/src/example/models/models_yaw_pitch_roll.rs
+++ b/showcase/src/example/models/models_yaw_pitch_roll.rs
@@ -47,7 +47,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         mats[raylib::consts::MaterialMapIndex::MATERIAL_MAP_ALBEDO as usize].texture = texture;
     }
 
-    let mut camera = Camera3D::perspective(
+    let camera = Camera3D::perspective(
         Vector3::new(0.0, 60.0, -120.0),
         Vector3::new(0.0, 12.0, 0.0),
         Vector3::new(0.0, 1.0, 0.0),

--- a/showcase/src/example/others/rlgl_standalone.rs
+++ b/showcase/src/example/others/rlgl_standalone.rs
@@ -77,7 +77,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         ffi::rlEnableDepthTest(); // Enable DEPTH_TEST for 3D
     }
 
-    let mut camera =
+    let camera =
         Camera3D::perspective(rvec3(5.0, 5.0, 5.0), Vector3::zero(), Vector3::up(), 45.0);
 
     let cube_position = Vector3::zero(); // Cube default position (center)

--- a/showcase/src/example/portable_window/portable_window.rs
+++ b/showcase/src/example/portable_window/portable_window.rs
@@ -32,14 +32,10 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
 
     // General variables
-    let mut mousePosition = Vector2::default();
     let  mut windowPosition = rvec2(500, 200);
-    let  mut panOffset = mousePosition;
     let mut  dragWindow = false;
 
     rl.set_window_position(windowPosition.x as i32, windowPosition.y as i32);
-
-    let mut  exitWindow = false;
 
     rl.set_target_fps(60);
     //--------------------------------------------------------------------------------------
@@ -49,7 +45,8 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     {
         // Update
         //----------------------------------------------------------------------------------
-        mousePosition = rl.get_mouse_position();
+        let mousePosition = rl.get_mouse_position();
+        let mut panOffset = mousePosition;
 
         if rl.is_mouse_button_pressed(raylib::consts::MouseButton::MOUSE_LEFT_BUTTON)
         {
@@ -80,7 +77,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
         d.clear_background(Color::RAYWHITE);
 
-        exitWindow = d.gui_window_box(rrect(0, 0, screen_width, screen_height), Some(rstr!("PORTABLE WINDOW")));
+        let _ = d.gui_window_box(rrect(0, 0, screen_width, screen_height), Some(rstr!("PORTABLE WINDOW")));
 
         d.draw_text(&format!("Mouse Position: [ {:.0}, {:.0} ]", mousePosition.x, mousePosition.y), 10, 40, 10, Color::DARKGRAY);
 

--- a/showcase/src/example/shaders/shaders_basic_lighting.rs
+++ b/showcase/src/example/shaders/shaders_basic_lighting.rs
@@ -129,28 +129,28 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
     // Using 4 point lights, white,Color::RED, green and blue
     let mut lights = [
         create_light(
-            LightType::LIGHT_POINT,
+            LightType::LightPoint,
             rvec3(4, 2, 4),
             Vector3::zero(),
             Color::WHITE,
             &mut shader,
         ),
         create_light(
-            LightType::LIGHT_POINT,
+            LightType::LightPoint,
             rvec3(4, 2, 4),
             Vector3::zero(),
             Color::RED,
             &mut shader,
         ),
         create_light(
-            LightType::LIGHT_POINT,
+            LightType::LightPoint,
             rvec3(0, 4, 2),
             Vector3::zero(),
             Color::GREEN,
             &mut shader,
         ),
         create_light(
-            LightType::LIGHT_POINT,
+            LightType::LightPoint,
             rvec3(0, 4, 2),
             Vector3::zero(),
             Color::BLUE,
@@ -211,7 +211,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         modelA.set_transform(&(*modelA.transform() * Matrix::rotate_z(0.012)));
 
         // Update the light shader with the camera view position
-        let mut cameraPos = Vector3::new(camera.position.x, camera.position.y, camera.position.z);
+        let cameraPos = Vector3::new(camera.position.x, camera.position.y, camera.position.z);
         let loc = shader.locs_mut()[raylib::consts::ShaderLocationIndex::SHADER_LOC_VECTOR_VIEW as usize];
         shader.set_shader_value( loc, cameraPos);
         //----------------------------------------------------------------------------------
@@ -278,13 +278,13 @@ const MAX_LIGHTS: u32 = 4;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum LightType {
-    LIGHT_DIRECTIONAL = 0,
-    LIGHT_POINT = 1,
+    LightDirectional = 0,
+    LightPoint = 1,
 }
 
 impl Default for LightType {
     fn default() -> Self {
-        Self::LIGHT_DIRECTIONAL
+        Self::LightDirectional
     }
 }
 

--- a/showcase/src/example/shaders/shaders_fog.rs
+++ b/showcase/src/example/shaders/shaders_fog.rs
@@ -71,7 +71,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         )
         .unwrap()
     };
-    let mut texture = rl
+    let texture = rl
         .load_texture(thread, "original/shaders/resources/texel_checker.png")
         .unwrap();
 
@@ -120,7 +120,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
 
     // Using just 1 point lights
     create_light(
-        LightType::LIGHT_POINT,
+        LightType::LightPoint,
         rvec3(0, 2, 6),
         Vector3::zero(),
         Color::WHITE,
@@ -210,13 +210,13 @@ const MAX_LIGHTS: u32 = 4;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum LightType {
-    LIGHT_DIRECTIONAL = 0,
-    LIGHT_POINT = 1,
+    LightDirectional = 0,
+    LightPoint = 1,
 }
 
 impl Default for LightType {
     fn default() -> Self {
-        Self::LIGHT_DIRECTIONAL
+        Self::LightDirectional
     }
 }
 

--- a/showcase/src/example/textures/textures_mouse_painting.rs
+++ b/showcase/src/example/textures/textures_mouse_painting.rs
@@ -65,7 +65,6 @@ pub fn run(mut rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
     let mut brush_size = 20;
 
     let btn_save_rec = rrect::<i32, i32, i32, i32>(750, 10, 40, 30);
-    let mut btn_save_mouse_hover = false;
     let mut show_save_message = false;
     let mut save_message_counter = 0;
 
@@ -171,11 +170,11 @@ pub fn run(mut rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut
             }
 
             // Check mouse hover save button
-            if btn_save_rec.check_collision_point_rec(mouse_pos) {
-                btn_save_mouse_hover = true;
+            let btn_save_mouse_hover = if btn_save_rec.check_collision_point_rec(mouse_pos) {
+                true
             } else {
-                btn_save_mouse_hover = false;
-            }
+                false
+            };
 
             // Image saving logic
             // NOTE: Saving painted texture to a default named image


### PR DESCRIPTION
This PR cleans up the warnings in the compilation of `raylib` and `raylib-showcase`, and updates the `rand` version in `raylib-examples` to 0.8. Some updates in `roguelike` are then necessary for the binary to compile.

I'd like to also run rustfmt on these files but it might cover up the changes in here, so maybe it can be done later.