### PR TITLE
Fixed the number of arguments for thread_rng gen_range

### DIFF
--- a/samples/3d_camera_first_person.rs
+++ b/samples/3d_camera_first_person.rs
@@ -14,13 +14,13 @@ struct Column {
 impl Column {
     fn create_random() -> Column {
         let mut rng = rand::thread_rng();
-        let height: f32 = rng.gen_range(1.0..12.0);
+        let height: f32 = rng.gen_range(1.0, 12.0);
         let position = Vector3::new(
-            rng.gen_range(-15.0..15.0),
+            rng.gen_range(-15.0, 15.0),
             height / 2.0,
-            rng.gen_range(-15.0..15.0),
+            rng.gen_range(-15.0, 15.0),
         );
-        let color = Color::new(rng.gen_range(20..255), rng.gen_range(10..55), 30, 255);
+        let color = Color::new(rng.gen_range(20, 255) as u8, rng.gen_range(10, 55) as u8, 30, 255);
 
         Column {
             height,


### PR DESCRIPTION
toolchain used: rustc 1.63.0-nightly (5750a6aa2 2022-06-20)
```
9402 error[E0277]: the trait bound `std::ops::Range<{float}>: SampleUniform` is not satisfied                                                                                                  
9403    --> samples/3d_camera_first_person.rs:17:41                                                                                                                                            
9404     |                                                                                                                                                                                     
9405 17  |         let height: f32 = rng.gen_range(1.0..12.0);                                                                                                                                 
9406     |                               --------- ^^^^^^^^^ the trait `SampleUniform` is not impl                                                                                             
9407 emented for `std::ops::Range<{float}>`                                                                                                                                                    
9408     |                               |                                                                                                                                                     
9409     |                               required by a bound introduced by this call        
```