### PR TITLE
issue #141 Color::get_color(i32) should use u32 

### DIFF
--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -129,7 +129,7 @@ impl Color {
 
     /// Returns a Color struct from hexadecimal value
     #[inline]
-    pub fn get_color(hex_value: i32) -> Color {
+    pub fn get_color(hex_value: u32) -> Color {
         unsafe { ffi::GetColor(hex_value).into() }
     }
 

--- a/showcase/src/example/controls_test_suite/controls_test_suite.rs
+++ b/showcase/src/example/controls_test_suite/controls_test_suite.rs
@@ -126,7 +126,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         // Draw
         //----------------------------------------------------------------------------------
         let mut d = rl.begin_drawing(&thread);
-        let hex = d.gui_get_style(DEFAULT, BACKGROUND_COLOR as i32);
+        let hex = d.gui_get_style(DEFAULT, BACKGROUND_COLOR as u32);
         d.clear_background(Color::get_color(hex));
 
         // raygui: controls drawing

--- a/showcase/src/example/image_exporter/image_exporter.rs
+++ b/showcase/src/example/image_exporter/image_exporter.rs
@@ -180,7 +180,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
             d.draw_texture_ex(&texture, rvec2(screen_width / 2 - (texture.width() as f32 * imageScale / 2.0) as i32,  screen_height / 2 - (texture.height() as f32 * imageScale / 2.0) as i32), 0.0, imageScale, Color::WHITE);
 
             d.draw_rectangle_lines_ex(imageRec, 1, if imageRec.check_collision_point_rec(d.get_mouse_position()) {Color::RED } else { Color::DARKGRAY});
-            d.draw_text(&format!("SCALE: {:.2}", imageScale * 100.0), 20, screen_height - 40, 20, Color::get_color(d.gui_get_style(raylib::consts::GuiControl::DEFAULT, raylib::consts::GuiDefaultProperty::LINE_COLOR as i32)));
+            d.draw_text(&format!("SCALE: {:.2}", imageScale * 100.0), 20, screen_height - 40, 20, Color::get_color(d.gui_get_style(raylib::consts::GuiControl::DEFAULT, raylib::consts::GuiDefaultProperty::LINE_COLOR as u32)));
         }
         else
         {
@@ -199,7 +199,7 @@ pub fn run(rl: &mut RaylibHandle, thread: &RaylibThread) -> crate::SampleOut {
         //-----------------------------------------------------------------------------
         if windowBoxActive
         {
-            d.draw_rectangle(0, 0, screen_width, screen_height, Color::get_color(d.gui_get_style(raylib::consts::GuiControl::DEFAULT, raylib::consts::GuiDefaultProperty::BACKGROUND_COLOR as i32)).fade( 0.7));
+            d.draw_rectangle(0, 0, screen_width, screen_height, Color::get_color(d.gui_get_style(raylib::consts::GuiControl::DEFAULT, raylib::consts::GuiDefaultProperty::BACKGROUND_COLOR as u32)).fade( 0.7));
             windowBoxActive = !d.gui_window_box(rrect(windowBoxRec.x, windowBoxRec.y, 220, 190), Some(rstr!("Image Export Options")));
 
             d.gui_label(rrect(windowBoxRec.x + 10.0, windowBoxRec.y + 35.0, 60, 25), Some(rstr!("File format:")));


### PR DESCRIPTION
I have changed the signed integer to an unsigned integer for the get_color function.