### PR TITLE
Updates from_euler parameter names to match raymath's QuaternionFromEuler

### DIFF
--- a/raylib/src/core/math.rs
+++ b/raylib/src/core/math.rs
@@ -1072,13 +1072,13 @@ impl Quaternion {
     }
 
     /// Returns a quaternion equivalent to Euler angles.
-    pub fn from_euler(roll: f32, pitch: f32, yaw: f32) -> Quaternion {
-        let x0 = (roll * 0.5).cos();
-        let x1 = (roll * 0.5).sin();
-        let y0 = (pitch * 0.5).cos();
-        let y1 = (pitch * 0.5).sin();
-        let z0 = (yaw * 0.5).cos();
-        let z1 = (yaw * 0.5).sin();
+    pub fn from_euler(pitch: f32, yaw: f32, roll: f32) -> Quaternion {
+        let x0 = (pitch * 0.5).cos();
+        let x1 = (pitch * 0.5).sin();
+        let y0 = (yaw * 0.5).cos();
+        let y1 = (yaw * 0.5).sin();
+        let z0 = (roll * 0.5).cos();
+        let z1 = (roll * 0.5).sin();
 
         Quaternion {
             x: (x1 * y0 * z0) - (x0 * y1 * z1),


### PR DESCRIPTION
This change reflects the fix done in https://github.com/raysan5/raylib/issues/1651. I found from_euler was not behaving as expected when changing yaw, pitch, and roll for a 3d camera. When I provide values in the the same order now used in raymath (pitch, yaw, roll), rotation behavior is as expected.