### PR TITLE
Add missing get_render_height function

### DIFF
--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -705,6 +705,12 @@ impl RaylibHandle {
         unsafe { ffi::GetRenderWidth() }
     }
 
+    /// Get current render height which is equal to screen height * dpi scale
+    #[inline]
+    pub fn get_render_height(&self) -> i32 {
+        unsafe { ffi::GetRenderHeight() }
+    }
+
     /// Get current screen height which is equal to screen height * dpi scale
     #[inline]
     pub fn get_screen_width(&self) -> i32 {


### PR DESCRIPTION
A function was missing from RaylibHandle to get current render height, I have added it. This is my first contribution, looking forward for suggestion to create better pull requests.
Regards,
Anshul Kumar
