### PR TITLE
fix: 'fade' to 'alpha' in deprecation warning

### DIFF
--- a/raylib/src/core/color.rs
+++ b/raylib/src/core/color.rs
@@ -145,7 +145,7 @@ impl Color {
 
     /// Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
     #[inline]
-    #[deprecated = "Has been superseded by .fade()"]
+    #[deprecated = "Has been superseded by .alpha()"]
     pub fn fade(&self, alpha: f32) -> Color {
         unsafe { ffi::Fade(self.into(), alpha).into() }
     }


### PR DESCRIPTION
I spent some time looking for the new 'fade' function, but discovered the warning had a typo and meant 'alpha'