### PR TITLE
Add get_render_height function to complement get_render_width

### DIFF
--- a/raylib/src/core/window.rs
+++ b/raylib/src/core/window.rs
@@ -705,7 +705,13 @@ impl RaylibHandle {
         unsafe { ffi::GetRenderWidth() }
     }
 
-    /// Get current screen height which is equal to screen height * dpi scale
+    /// Get current render height which is equal to screen height * dpi scale
+    #[inline]
+    pub fn get_render_height(&self) -> i32 {
+        unsafe { ffi::GetRenderHeight() }
+    }
+
+    /// Gets current screen width.
     #[inline]
     pub fn get_screen_width(&self) -> i32 {
         unsafe { ffi::GetScreenWidth() }


### PR DESCRIPTION
Implemented the `get_render_height` method to retrieve the current render height, similar to the existing `get_render_width`. This function provides the screen height scaled by the DPI, aligning with the library's interface consistency.