### PR TITLE
impl `DerefMut` for RaylibDrawHandle

### DIFF
--- a/raylib/src/core/drawing.rs
+++ b/raylib/src/core/drawing.rs
@@ -44,6 +44,11 @@ impl<'a> std::ops::Deref for RaylibDrawHandle<'a> {
         &self.0
     }
 }
+impl<'a> std::ops::DerefMut for RaylibDrawHandle<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 impl<'a> RaylibDraw for RaylibDrawHandle<'a> {}
 


### PR DESCRIPTION
hello, i've been working on a side project for a couple of months now and i keep running into issues where some of the functions i need to use are only implemented for `RaylibHandle`, but i'm in the draw loop and the current handle is a `RaylibDrawHandle`.

i don't know if there's a safety reason behind not allowing `DerefMut` from `&mut RaylibDrawHandle` to `&mut RaylibHandle`, but if not then i think this change prevents unnecessary ffi calls. 