### PR TITLE
Simplify texture example

### DIFF
--- a/samples/texture.rs
+++ b/samples/texture.rs
@@ -8,13 +8,9 @@ fn main() {
     let opt = options::Opt::from_args();
     let (mut rl, thread) = opt.open_window("Texture");
     let (_w, _h) = (opt.width, opt.height);
-    let i = Image::load_image("static/billboard.png").expect("could not load image billboard");
-    let _ = rl
+    let t = rl
         .load_texture(&thread, "static/billboard.png")
         .expect("could not load texture billboard");
-    let t = rl
-        .load_texture_from_image(&thread, &i)
-        .expect("could not load texture from image");
 
     rl.set_target_fps(60);
     while !rl.window_should_close() {


### PR DESCRIPTION
In the current example there are two methods of loading an image, load_texture and load_texture_from_image and only the latter one is actually used.
I simplified it by leaving only the call to load_texture.